### PR TITLE
Fix circular dependency in auth flow

### DIFF
--- a/src/main/java/ru/solution/test_task_for_gitflic_team/controller/AuthController.java
+++ b/src/main/java/ru/solution/test_task_for_gitflic_team/controller/AuthController.java
@@ -3,6 +3,9 @@ package ru.solution.test_task_for_gitflic_team.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import lombok.extern.slf4j.Slf4j;
 import ru.solution.test_task_for_gitflic_team.dto.DtoMapper;
@@ -17,6 +20,7 @@ import ru.solution.test_task_for_gitflic_team.service.UserService;
 @Slf4j
 public class AuthController {
     private final UserService userService;
+    private final AuthenticationManager authenticationManager;
 
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.CREATED)
@@ -30,7 +34,11 @@ public class AuthController {
     @PostMapping("/login")
     public UserResponseDto login(@RequestBody @Valid UserDto dto) {
         log.info("Login attempt for user: {}", dto.username());
-        User user = userService.login(dto.username(), dto.password());
+        var authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(dto.username(), dto.password()));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        User user = (User) authentication.getPrincipal();
+        user.setPassword(null);
         log.info("User {} successfully authenticated", dto.username());
         return DtoMapper.toDto(user);
     }

--- a/src/main/java/ru/solution/test_task_for_gitflic_team/service/UserService.java
+++ b/src/main/java/ru/solution/test_task_for_gitflic_team/service/UserService.java
@@ -5,5 +5,4 @@ import ru.solution.test_task_for_gitflic_team.entity.User;
 
 public interface UserService extends UserDetailsService {
     User register(String username, String password);
-    User login(String username, String password);
 }

--- a/src/main/java/ru/solution/test_task_for_gitflic_team/service/UserServiceImpl.java
+++ b/src/main/java/ru/solution/test_task_for_gitflic_team/service/UserServiceImpl.java
@@ -2,9 +2,6 @@ package ru.solution.test_task_for_gitflic_team.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,7 +16,6 @@ import ru.solution.test_task_for_gitflic_team.exception.Exception;
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final AuthenticationManager authenticationManager;
 
     @Override
     @Transactional(readOnly = true)
@@ -52,13 +48,4 @@ public class UserServiceImpl implements UserService {
         return registeredUser;
     }
 
-    @Override
-    public User login(String username, String password) {
-        var authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(username, password));
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        User user = (User) authentication.getPrincipal();
-        user.setPassword(null);
-        return user;
-    }
 }


### PR DESCRIPTION
## Summary
- remove `login` method from `UserService` and its impl
- authenticate users directly in `AuthController`

This breaks the cycle between `UserServiceImpl` and `AuthenticationManager` so beans can be created normally.

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688b33784a8883279b6f36224727f4d9